### PR TITLE
Added support for booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # SAC JSON Module
 ## About
 This is a Sac module that wraps around some of the [cJSON](https://github.com/DaveGamble/cJSON) library. Currently this is a work in progress.
+
+## Supported Functionality
+- Creating of empty json object.
+- Adding booleans to json objects.
+- Serializing json objects to stdout.
+
 ## Build Instructions
 You'll need to have installed sac2c and have a copy of the Stdlib installed as well.
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,10 +5,23 @@ sac2c FILENAME.sac
 ./a.out
 ```
 ## Files
-### `printing_json.sac`
+### `printing_json_empty.sac`
 Creates an empty json object and outputs it to stdout.
 expected result:
-```bash
+```json
 {
+}
+```
+
+### `printing_json_booleans.sac`
+Creates a json object and sets some booleans in various ways.
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"isTrue":		true,
+	"isFalse":		false,
+	"isAlsoTrue":	true,
+	"isAlsoFalse":	false
 }
 ```

--- a/examples/printing_json.sac
+++ b/examples/printing_json.sac
@@ -1,9 +1,0 @@
-use StdIO: all;
-use JSON: all;
-
-int main()
-{
-	json_object = createJSONObject();
-	serializeJSONObject(json_object);
-	return 0;
-}

--- a/examples/printing_json_booleans.sac
+++ b/examples/printing_json_booleans.sac
@@ -1,0 +1,13 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setBool(json_object, "isTrue", true);
+	setBool(json_object, "isFalse", false);
+	setTrue(json_object, "isAlsoTrue");
+	setFalse(json_object, "isAlsoFalse");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/examples/printing_json_empty.sac
+++ b/examples/printing_json_empty.sac
@@ -1,0 +1,13 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setBool(json_object, "isTrue", true);
+	setBool(json_object, "isFalse", false);
+	setTrue(json_object, "isAlsoTrue");
+	setFalse(json_object, "isAlsoFalse");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -1,6 +1,7 @@
 module JSONBuilder;
 
 use JSONObject: all;
+use String: {string};
 use Terminal: {TheTerminal};
 
 export all;
@@ -9,6 +10,21 @@ external JSONObject createJSONObject();
 	#pragma linkname "create_object"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [0]
+
+external void setBool( JSONObject& object, string key, bool boolean);
+	#pragma linkname "set_bool"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+
+external void setTrue( JSONObject& object, string key);
+	#pragma linkname "set_true"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2]
+
+external void setFalse( JSONObject& object, string key);
+	#pragma linkname "set_false"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2]
 
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -1,9 +1,27 @@
 #include <cjson/cJSON.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 cJSON * create_object()
 {
 	return cJSON_CreateObject();
+}
+
+void set_bool( cJSON * object, char * key, bool boolean)
+{
+	cJSON * val;
+	val = boolean ? cJSON_CreateTrue() : cJSON_CreateFalse();
+	cJSON_AddItemToObject(object, key, val);
+}
+
+void set_true( cJSON * object, char * key) 
+{
+	set_bool(object, key, true);
+}
+
+void set_false( cJSON * object, char * key) 
+{
+	set_bool(object, key, false);
 }
 
 void serialize_object( cJSON* object)


### PR DESCRIPTION
Added:
- `setBool` function allows adding a boolean to the specified json object
- `setTrue` function allows adding a true to the specified json object
- `setFalse` function allows adding a false to the specified json object

Changed:
- Updated example files to demonstrate new functionality
- Updated example/readme to reflect changes
- Updated readme to reflect changes