### PR TITLE
Added support for adding numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This is a Sac module that wraps around some of the [cJSON](https://github.com/Da
 ## Supported Functionality
 - Creating of empty json object.
 - Adding booleans to json objects.
+- Adding integers to json objects.
+- Adding floats to json objects.
+- Adding doubles to json objects.
 - Serializing json objects to stdout.
 
 ## Build Instructions

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,3 +25,15 @@ expected result:
 	"isAlsoFalse":	false
 }
 ```
+
+### `printing_json_numbers.sac`
+Creates a json object and sets numbers in various ways (int, float, double).
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"integer":	42,
+	"float":	1.2000000476837158,
+	"double":	3.4
+}
+```

--- a/examples/printing_json_empty.sac
+++ b/examples/printing_json_empty.sac
@@ -4,10 +4,6 @@ use JSON: all;
 int main()
 {
 	json_object = createJSONObject();
-	setBool(json_object, "isTrue", true);
-	setBool(json_object, "isFalse", false);
-	setTrue(json_object, "isAlsoTrue");
-	setFalse(json_object, "isAlsoFalse");
 	serializeJSONObject(json_object);
 	return 0;
 }

--- a/examples/printing_json_numbers.sac
+++ b/examples/printing_json_numbers.sac
@@ -1,0 +1,22 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setInt(json_object, "integer", 42);
+	setFloat(json_object, "float", 1.2f);
+	setDouble(json_object, "double", 3.4);
+	serializeJSONObject(json_object);
+	return 0;
+}
+
+// float getFloat()
+// {
+// 	return 1.2f;
+// }
+
+// double getDouble()
+// {
+// 	return 3.4;
+// }

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -11,6 +11,7 @@ external JSONObject createJSONObject();
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [0]
 
+// Booleans
 external void setBool( JSONObject& object, string key, bool boolean);
 	#pragma linkname "set_bool"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
@@ -25,6 +26,20 @@ external void setFalse( JSONObject& object, string key);
 	#pragma linkname "set_false"
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [1, 2]
+
+// Numbers
+external void setInt( JSONObject& object, string key, int value);
+	#pragma linkname "set_int"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+external void setFloat( JSONObject& object, string key, float value);
+	#pragma linkname "set_float"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+external void setDouble( JSONObject& object, string key, double value);
+	#pragma linkname "set_double"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
 
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -7,21 +7,40 @@ cJSON * create_object()
 	return cJSON_CreateObject();
 }
 
+// Booleans
 void set_bool( cJSON * object, char * key, bool boolean)
 {
 	cJSON * val;
 	val = boolean ? cJSON_CreateTrue() : cJSON_CreateFalse();
 	cJSON_AddItemToObject(object, key, val);
 }
-
 void set_true( cJSON * object, char * key) 
 {
 	set_bool(object, key, true);
 }
-
 void set_false( cJSON * object, char * key) 
 {
 	set_bool(object, key, false);
+}
+
+// Numbers
+void set_int( cJSON * object, char * key, int value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber(value);
+	cJSON_AddItemToObject(object, key, val);
+}
+void set_float( cJSON * object, char * key, float value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber((double)value);
+	cJSON_AddItemToObject(object, key, val);
+}
+void set_double( cJSON * object, char * key, double value)
+{
+	cJSON * val;
+	val = cJSON_CreateNumber(value);
+	cJSON_AddItemToObject(object, key, val);
 }
 
 void serialize_object( cJSON* object)


### PR DESCRIPTION
Added:
- `setInt` function allows adding an int to the specified json object.
- `setFloat` function allows adding a float to the specified json object.
- `setDouble` function allows adding a double to the specified json oject.
- the example `printing_json_numbers` demonstrating new functionality.

Changed:
- `examples/README` reflecting new functionality.
- `README` reflecting new functionality.