### PR TITLE
Added support for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Sac module that wraps around some of the [cJSON](https://github.com/Da
 - Adding integers to json objects.
 - Adding floats to json objects.
 - Adding doubles to json objects.
+- Adding strings to json objects.
 - Serializing json objects to stdout.
 
 ## Build Instructions

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,3 +37,13 @@ expected result:
 	"double":	3.4
 }
 ```
+
+### `printing_json_string.sac`
+Creates a json object and sets a string.
+Then outputs the json object to stdout.
+expected result:
+```json
+{
+	"aString":	"Hello World!"
+}
+```

--- a/examples/printing_json_numbers.sac
+++ b/examples/printing_json_numbers.sac
@@ -10,13 +10,3 @@ int main()
 	serializeJSONObject(json_object);
 	return 0;
 }
-
-// float getFloat()
-// {
-// 	return 1.2f;
-// }
-
-// double getDouble()
-// {
-// 	return 3.4;
-// }

--- a/examples/printing_json_string.sac
+++ b/examples/printing_json_string.sac
@@ -1,0 +1,10 @@
+use StdIO: all;
+use JSON: all;
+
+int main()
+{
+	json_object = createJSONObject();
+	setString(json_object, "aString", "Hello World!");
+	serializeJSONObject(json_object);
+	return 0;
+}

--- a/src/JSONBuilder.sac
+++ b/src/JSONBuilder.sac
@@ -41,6 +41,12 @@ external void setDouble( JSONObject& object, string key, double value);
 	#pragma linkobj "src/JSONBuilder/json_builder.o"
 	#pragma linksign [1, 2, 3]
 
+// String
+external void setString( JSONObject& object, string key, string value);
+	#pragma linkname "set_string"
+	#pragma linkobj "src/JSONBuilder/json_builder.o"
+	#pragma linksign [1, 2, 3]
+
 external void serializeJSONObject( JSONObject& object);
 	#pragma effect TheTerminal
 	#pragma linkname "serialize_object"

--- a/src/src/JSONBuilder/json_builder.c
+++ b/src/src/JSONBuilder/json_builder.c
@@ -43,6 +43,14 @@ void set_double( cJSON * object, char * key, double value)
 	cJSON_AddItemToObject(object, key, val);
 }
 
+// String
+void set_string( cJSON * object, char * key, char * value)
+{
+	cJSON * val;
+	val = cJSON_CreateString(value);
+	cJSON_AddItemToObject(object, key, val);
+}
+
 void serialize_object( cJSON* object)
 {
 	char * str;


### PR DESCRIPTION
Added:
- `setString` function allows adding a string to the specified json object
- `examples/printing_json_string.sac` demonstrating new functionality

Changed:
- `examples/README` reflecting new functionality
- `README` reflecting new functionality